### PR TITLE
Don't show the middle bar if we are on the privacy policy or more page

### DIFF
--- a/tarteaucitron.js
+++ b/tarteaucitron.js
@@ -219,8 +219,8 @@ var tarteaucitron = {
             },
             params = tarteaucitron.parameters;
 
-        // Don't show the middle bar if we are on the privacy policy page
-        if (window.location.href == tarteaucitron.parameters.privacyUrl && tarteaucitron.parameters.orientation == "middle") {
+        // Don't show the middle bar if we are on the privacy policy or more page
+        if (((tarteaucitron.parameters.readmoreLink !== undefined && window.location.href == tarteaucitron.parameters.readmoreLink) || window.location.href == tarteaucitron.parameters.privacyUrl) && tarteaucitron.parameters.orientation == "middle") {
             tarteaucitron.parameters.orientation = "bottom";
         }
 


### PR DESCRIPTION
Don't show the middle bar if we are on the privacy policy or more page, usefull if the more page is on your website.